### PR TITLE
Introduced integer LR with tie breaking

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,9 @@ uuid = "b16ff44f-713d-4727-b6c3-8709e5be8a88"
 authors = ["Kasper Risager"]
 version = "0.1.0-DEV"
 
+[deps]
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
 [compat]
 julia = "1"
 

--- a/src/Apportionment.jl
+++ b/src/Apportionment.jl
@@ -1,5 +1,8 @@
 module Apportionment
 
+using Random
+
+include("Utilities.jl")
 include("LargestRemainders.jl")
 
 end

--- a/src/LargestRemainders.jl
+++ b/src/LargestRemainders.jl
@@ -2,16 +2,18 @@ struct LargestRemainders
     total_items::Int
 end
 
-function apportion(entitlements, lr::LargestRemainders)
-    quotas = entitlements / sum(entitlements) * lr.total_items
+function apportion_quotas(quotas::AbstractVector{<:Real}, lr::LargestRemainders, tie_breaker)
     items = floor.(Int, quotas)
     remaining_items = lr.total_items - sum(items)
-    if remaining_items == 0
-        return items
-    end
-    remaining_quotas = quotas - items
-    required_remaining_quota = remaining_quotas[partialsortperm(remaining_quotas, remaining_items, rev = true)]
-    return items + (remaining_quotas .>= required_remaining_quota)
+    return items + indicate_largest(quotas - items, remaining_items, tie_breaker)
+end
+
+function apportion(entitlements::AbstractVector{<:Real}, lr::LargestRemainders)
+    return apportion_quotas(entitlements / sum(entitlements) * lr.total_items, lr, LazyTieBreaker())
+end
+
+function apportion(entitlements::Vector{<:Union{Integer, Rational}}, lr::LargestRemainders)
+    return apportion_quotas(entitlements // sum(entitlements) * lr.total_items, lr, ShuffleTieBreaker())
 end
 
 export LargestRemainders, apportion

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -1,0 +1,27 @@
+struct ShuffleTieBreaker end
+struct LazyTieBreaker end
+
+function chosen(i::AbstractVector, n, ::ShuffleTieBreaker)
+    return shuffle(i)[1:n]
+end
+
+function chosen(i::AbstractVector, n, ::LazyTieBreaker)
+    return i[1:n]
+end
+
+function indicate_largest(v::AbstractVector{<:Real}, n, tie_breaker)
+    if n == 0
+        return zeros(Bool, (length(v),))
+    end
+    c = v[partialsortperm(v, n, rev = true)]
+    largest = v .> c
+    equals_needed = n - sum(largest)
+    equidxs = findall(v .== c)
+    if equals_needed < length(equidxs)
+        equidxs = chosen(equidxs, equals_needed, tie_breaker)
+    end
+    for eqidx in equidxs
+        largest[eqidx] = true
+    end
+    return largest
+end

--- a/test/LargestRemainders.jl
+++ b/test/LargestRemainders.jl
@@ -1,9 +1,16 @@
 @testset "Largest remainders" begin
     
     lr3 = LargestRemainders(3)
-    entitlements = [5.6, 2.6]
 
-    @test apportion(entitlements, lr3) == [2, 1]
+    @test apportion([5.6, 2.6], lr3) == [2, 1]
+    @test apportion([3.0, 3.0], lr3) == [2, 1] # uses LazyTieBreaker, so always chooses first
+
+    @test apportion([5, 3], lr3) == [2, 1]
+    @test apportion([3, 3], lr3) ∈ [[2, 1], [1, 2]] # uses ShuffleTieBreaker, so we don't know which
+
+    @test apportion([5+1//3, 3+5//13], lr3) == [2, 1]
+    @test apportion([5+1//3, 5+1//3], lr3) ∈ [[2, 1], [1, 2]] # uses ShuffleTieBreaker, so we don't know which
+
 
     # Danish general election 2019, only parties above threshold
     entitlements = [
@@ -24,5 +31,6 @@
     ]
 
     @test apportion(entitlements, LargestRemainders(175)) == expected_apportionment
+    @test apportion(float(entitlements), LargestRemainders(175)) == expected_apportionment
 
 end

--- a/test/Utilities.jl
+++ b/test/Utilities.jl
@@ -1,0 +1,42 @@
+import Apportionment: LazyTieBreaker, ShuffleTieBreaker
+import Apportionment: chosen, indicate_largest
+
+function test_shuffle_tie_breaker(base, n, result)
+    @test allunique(result)
+    @test length(result) == n
+    @test all(result .∈ Ref(base))
+end
+
+@testset "Tie Breakers" begin
+    
+    i = [5, 7, 3]
+    tie_breaker = LazyTieBreaker()
+    @test chosen(i, 0, tie_breaker) == []
+    @test chosen(i, 1, tie_breaker) == [5]
+    @test chosen(i, 2, tie_breaker) == [5, 7]
+    @test chosen(i, 3, tie_breaker) == [5, 7, 3]
+
+    tie_breaker = ShuffleTieBreaker()
+    test_shuffle_tie_breaker(i, 0, chosen(i, 0, tie_breaker))
+    test_shuffle_tie_breaker(i, 1, chosen(i, 1, tie_breaker))
+    test_shuffle_tie_breaker(i, 2, chosen(i, 2, tie_breaker))
+    test_shuffle_tie_breaker(i, 3, chosen(i, 3, tie_breaker))
+
+end
+
+@testset "Indicate largest" begin
+    
+    tie_breaker = LazyTieBreaker()
+
+    @test indicate_largest(Int[], 0, tie_breaker) == Bool[]
+    @test indicate_largest([3, 4], 0, tie_breaker) == [false, false]
+    @test indicate_largest([3, 4], 2, tie_breaker) == [true , true ]
+
+    @test indicate_largest([3, 7, 4], 1, tie_breaker) == [false, true, false]
+    @test indicate_largest([3, 7, 4], 2, tie_breaker) == [false, true, true ]
+
+    @test indicate_largest([4, 7, 3, 4], 1, tie_breaker) == [false, true, false, false]
+    @test indicate_largest([4, 7, 3, 4], 2, tie_breaker) == [true , true, false, false]
+    @test indicate_largest([4, 7, 3, 4], 3, tie_breaker) == [true , true, false, true ]
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using Apportionment
 using Test
 
+include("Utilities.jl")
 include("LargestRemainders.jl")


### PR DESCRIPTION
Fixes #4 by
* introducing two different tie breaking rules
* introducing a new `apportion` method for integer and rational entitlements that does random tie breaking
* letting the exisiting method for real entitlement use a tie breaking that just uses the first occurrance, since this should not matter for real entitlements

Additionally, refactors and tests.